### PR TITLE
Fix: Duration ocr & late stop in assignment

### DIFF
--- a/module/ocr/ocr.py
+++ b/module/ocr/ocr.py
@@ -283,7 +283,7 @@ class Duration(Ocr):
     @cached_property
     def timedelta_regex(self):
         regex_str = {
-            'ch': r'\D*((?P<days>\d{1,2})天)?((?P<hours>\d{1,2})小时)?((?P<minutes>\d{1,2})分钟)?((?P<seconds>\d{1,2})秒})?',
+            'ch': r'\D*((?P<days>\d{1,2})天)?((?P<hours>\d{1,2})小时)?((?P<minutes>\d{1,2})分钟)?((?P<seconds>\d{1,2})秒)?',
             'en': r'\D*((?P<days>\d{1,2})d\s*)?((?P<hours>\d{1,2})h\s*)?((?P<minutes>\d{1,2})m\s*)?((?P<seconds>\d{1,2})s)?'
         }[self.lang]
         return re.compile(regex_str)

--- a/tasks/assignment/assignment.py
+++ b/tasks/assignment/assignment.py
@@ -26,6 +26,7 @@ class Assignment(AssignmentClaim, SynthesizeUI):
         if duration is None:
             duration = self.config.Assignment_Duration
 
+        self.dispatched = dict()
         self.ensure_scroll_top(page_menu)
         self.ui_ensure(page_assignment)
         # Iterate in user-specified order, return undispatched ones
@@ -103,6 +104,8 @@ class Assignment(AssignmentClaim, SynthesizeUI):
                 if self.appear(DISPATCHED):
                     self.dispatched[assignment] = datetime.now() + Duration(
                         OCR_ASSIGNMENT_TIME).ocr_single_line(self.device.image)
+                    if total == len(self.dispatched):
+                        return remain
                     continue
                 break
         return remain


### PR DESCRIPTION
修了三个问题

- 正则错误导致ocr后结果没有秒数；
- 遍历委托时，`dispatched`数量达到上限时即可停止，不必继续遍历；
- 委托类中将`dispatched`改为实例变量，否则SRC单轮运行时，每次调度委托都会保留上次`dispatched`的内容。

群里zzb发的日志里出现的OCR时间为0的问题，我不太确定是OCR没识别到还是正则没匹配上（应该是前者），也不太确定结果为0时要怎么处理比较合适……