### PR TITLE
Fix: Assignments missing groups

### DIFF
--- a/module/ui/draggable_list.py
+++ b/module/ui/draggable_list.py
@@ -159,6 +159,7 @@ class DraggableList:
             return False
 
         logger.info(f'Insight row: {row}, index={row_index}')
+        last_buttons: set[OcrResultButton] = None
         while 1:
             if skip_first_screenshot:
                 skip_first_screenshot = False
@@ -181,6 +182,10 @@ class DraggableList:
             main.wait_until_stable(self.search_button, timer=Timer(
                 0, count=0), timeout=Timer(1.5, count=5))
             skip_first_screenshot = True
+            if last_buttons == set(self.cur_buttons):
+                logger.warning(f'No more rows in {self}')
+                return False
+            last_buttons = set(self.cur_buttons)
 
         return True
 

--- a/tasks/assignment/keywords/__init__.py
+++ b/tasks/assignment/keywords/__init__.py
@@ -20,6 +20,8 @@ KEYWORDS_ASSIGNMENT_GROUP.Synthesis_Materials.entries = (
     KEYWORDS_ASSIGNMENT_ENTRY.Spring_of_Life,
     KEYWORDS_ASSIGNMENT_ENTRY.The_Land_of_Gold,
     KEYWORDS_ASSIGNMENT_ENTRY.The_Blossom_in_the_Storm,
+    KEYWORDS_ASSIGNMENT_ENTRY.Legend_of_the_Puppet_Master,
+    KEYWORDS_ASSIGNMENT_ENTRY.The_Wages_of_Humanity,
 )
 for group in (
         KEYWORDS_ASSIGNMENT_GROUP.Character_Materials,
@@ -27,4 +29,5 @@ for group in (
         KEYWORDS_ASSIGNMENT_GROUP.Synthesis_Materials,
 ):
     for entry in group.entries:
+        assert entry.group is None
         entry.group = group


### PR DESCRIPTION
- 加了两个新委托对应的分组信息；
- 在找不到分组的时候尝试遍历列表查找，作为一定容错。为了实现这一点，在`DraggableList`中加了“没有更多行”的判断，感觉这里可能会有隐患，不行的话就回退吧（；
- 修了`server.lang`变动导致ocr的`after_process`没有生效的问题