### PR TITLE
Fix: Loop call of update_battle_pass_quests

### DIFF
--- a/tasks/battle_pass/battle_pass.py
+++ b/tasks/battle_pass/battle_pass.py
@@ -312,14 +312,15 @@ class BattlePassUI(UI):
             if self.appear(MAIN_GOTO_BATTLE_PASS, similarity=0.75):
                 return True
             else:
-                logger.info('No battle pass entrance, probably a gap between two periods')
                 continue
 
+        logger.info('No battle pass entrance, probably a gap between two periods')
         return False
 
     def run(self):
         self.ui_ensure(page_main)
         if not self.has_battle_pass_entrance():
+            self.config.stored.BattlePassTodayQuest.set(0)
             self.config.task_delay(server_update=True)
             self.config.task_stop()
 


### PR DESCRIPTION
`BattlePassTodayQuest`未过期、大月卡未满级、没有大月卡入口时，大月卡任务会被反复调用
#150 #151