### PR TITLE
Fix: store immersifiers ocr

### DIFF
--- a/module/ocr/ocr.py
+++ b/module/ocr/ocr.py
@@ -346,6 +346,28 @@ class Digit(Ocr):
             return 0
 
 
+class DigitLast(Ocr):
+    def __init__(self, button: ButtonWrapper, lang='en', name=None):
+        super().__init__(button, lang=lang, name=name)
+
+    def format_result(self, result) -> int:
+        """
+        for example '5:8', return 8
+
+        Returns:
+            int:
+        """
+        result = super().after_process(result)
+        logger.attr(name=self.name, text=str(result))
+
+        res = re.findall(r'(\d+)', result)
+        if res:
+            return int(res[-1])
+        else:
+            logger.warning(f'No digit found in {result}')
+            return 0
+
+
 class DigitCounter(Ocr):
     def __init__(self, button: ButtonWrapper, lang='en', name=None):
         super().__init__(button, lang=lang, name=name)

--- a/tasks/dungeon/stamina.py
+++ b/tasks/dungeon/stamina.py
@@ -1,6 +1,6 @@
 from module.base.timer import Timer
 from module.logger import logger
-from module.ocr.ocr import Digit
+from module.ocr.ocr import DigitLast
 from tasks.base.page import page_guide
 from tasks.dungeon.assets.assets_dungeon_stamina import *
 from tasks.dungeon.ui import DungeonUI
@@ -54,7 +54,7 @@ class DungeonStamina(DungeonUI):
             skip_first_screenshot=True,
     ):
         logger.info(f'Item amount set to {amount}')
-        ocr = Digit(ocr_button)
+        ocr = DigitLast(ocr_button)
         interval = Timer(1, count=3)
         while 1:
             if skip_first_screenshot:


### PR DESCRIPTION
储存沉浸器的时候, '兑换数量 : x' 的ocr结果有大概率是 '5 : x' / '5% : x' 等, 导致脚本误检测为5
增加DigitLast类, 返回最后一个数字, DungeonStamina._item_amount_set() 改为使用该类