### PR TITLE
Fix: Check indexes before using min()

### DIFF
--- a/tasks/dungeon/ui.py
+++ b/tasks/dungeon/ui.py
@@ -165,6 +165,11 @@ class DraggableDungeonList(DraggableList):
             indexes = [self.keyword2index(row.matched_keyword)
                        for row in self.cur_buttons]
             indexes = [index for index in indexes if index]
+
+            if not indexes:
+                logger.warning(f'No valid rows loaded into {self}')
+                return
+
             self.cur_min = min(indexes)
             self.cur_max = max(indexes)
             logger.attr(self.name, f'{self.cur_min} - {self.cur_max}')


### PR DESCRIPTION
DraggableDungeonList重写的load_rows()里在min(indexes)前没有检查indexes是否为空，导致如果第一次循环没有结果就直接报错