### PR TITLE
Fix:Stuck at Gacha when Himeko Trail

### DIFF
--- a/tasks/daily/trail.py
+++ b/tasks/daily/trail.py
@@ -74,6 +74,10 @@ class CharacterTrial(UI):
                     first_gacha = False
                 self.device.click(REGULAR_GACHA_CLICK)
                 continue
+            # Slide down to find Himeko gacha
+            if first_gacha:
+                self.device.swipe((70, 520), (70, 180))
+                self.wait_until_stable(REGULAR_GACHA_CHECK)
 
     def exit_trial(self, skip_first_screenshot=True):
         """


### PR DESCRIPTION
修复bug: 姬子试用卡在抽卡界面
新手卡池未抽完时，常驻卡池在最下方页面外，无法正常识别，导致在姬子试用环节卡死。
通过添加了左侧的卡池滑动动作，显示出卡池，以防止此bug。

Fix:Stuck at Gacha when Himeko Trail
In Himeko Trial, if beginner's gacha remains, target gacha will be outside of the page,  thus program stuch at gacha page.
Add slide action on left of the page to fix it.