### PR TITLE
Fix: Anniversary 3x get remain at combat

### DIFF
--- a/tasks/dungeon/event.py
+++ b/tasks/dungeon/event.py
@@ -74,8 +74,8 @@ class DungeonEvent(UI):
         # Anniversary 3x event
         has |= self.image_color_count(
             OCR_DOUBLE_EVENT_REMAIN_AT_COMBAT,
-            color=(230, 160, 100),
-            threshold=240, count=1000
+            color=(229, 62, 44),
+            threshold=221, count=50
         )
         logger.attr('Double event at combat', has)
         return has

--- a/tasks/dungeon/event.py
+++ b/tasks/dungeon/event.py
@@ -71,6 +71,12 @@ class DungeonEvent(UI):
             color=(231, 188, 103),
             threshold=240, count=1000
         )
+        # Anniversary 3x event
+        has |= self.image_color_count(
+            OCR_DOUBLE_EVENT_REMAIN_AT_COMBAT,
+            color=(230, 160, 100),
+            threshold=240, count=1000
+        )
         logger.attr('Double event at combat', has)
         return has
 


### PR DESCRIPTION
修复在关卡界面检测不到三倍活动，导致无法全部完成三倍次数的问题