### PR TITLE
Fix: Add handle_blessing_popup in blessing choosing

### DIFF
--- a/tasks/rogue/blessing/blessing.py
+++ b/tasks/rogue/blessing/blessing.py
@@ -187,6 +187,9 @@ class RogueBlessingSelector(RogueSelector):
             else:
                 self.main.device.screenshot()
 
+            if self.main.handle_blessing_popup():
+                logger.warning('Mistakenly recognized current page as blessing choosing page, quit')
+                return
             if is_card_selected(self.main, target, confirm_button=BLESSING_CONFIRM):
                 if enforce:
                     logger.info("Buff selected (enforce)")


### PR DESCRIPTION
在选择能够获得新祝福的奇物时，有可能会先进入命途回响的选择页面，然后过了一小会才弹出“获得祝福”页面，导致脚本先进入选择命途回响的分支，一直尝试选择获得的祝福，最后卡死。

这个commit在尝试选择祝福时增加了关于popup的判断。

一个例子：
[1707707542599.zip](https://github.com/LmeSzinc/StarRailCopilot/files/15221343/1707707542599.zip)

实际上还有一个问题有待解决。如果出现以上情况，脚本会重启，然后由于login里没有处理命途回响的选择页面，所以会继续卡死，直到重启次数达到上限。