### PR TITLE
Sync requirements-in.txt with requirements.txt

### DIFF
--- a/requirements-in.txt
+++ b/requirements-in.txt
@@ -9,16 +9,16 @@ adbutils==1.2.9
 uiautomator2==2.16.17
 uiautomator2cache==0.3.1
 wrapt>=1.14.0
-lz4
+lz4==4.3.2
 av==10.0.0
 psutil==5.9.3
 
 # Utils
-rich
-tqdm
-jellyfish
-pyyaml
-inflection
+rich==13.3.5
+tqdm==4.65.0
+jellyfish==0.11.2
+pyyaml==6.0
+inflection==0.5.1
 prettytable==2.2.1
 pydantic>=2.4
 onepush==1.3.0
@@ -37,4 +37,4 @@ srcmap==2.3.20240701
 
 # For dev
 # pip-tools
-pynput
+pynput==1.7.6


### PR DESCRIPTION
修复 #669，由 rich 版本过新导致