### PR TITLE
Opt: Expand width of menu button

### DIFF
--- a/assets/gui/css/alas.css
+++ b/assets/gui/css/alas.css
@@ -39,6 +39,7 @@ footer {
     transition: border .05s ease-in-out, padding .05s ease-in-out;
     white-space: pre-wrap;
     text-align: left;
+    width: 100%;
 }
 
 .btn-menu:hover,


### PR DESCRIPTION
导航菜单中，有些项目的宽度较窄（如“委托”），鼠标不容易点到。

将 `btn-menu` 类的宽度设置为 100%，使其宽度扩展至与侧栏相当，方便鼠标点击。

![image](https://github.com/user-attachments/assets/b84bf674-1339-4c62-9744-56805808be90)
