### PR TITLE
Fix Bug: Incorrectly identifying ascension of Cerydra

### DIFF
--- a/tasks/planner/scan.py
+++ b/tasks/planner/scan.py
@@ -48,6 +48,8 @@ class OcrItemName(Ocr):
         result = re.sub('[般殷]子', '骰子', result)
         # 暗帷月华
         result = result.replace('暗惟', '暗帷')
+        # 暮辉烬蕾
+        result = re.sub('暮晖.?蕾', '暮晖烬蕾', result)
         return result
 
 


### PR DESCRIPTION
修正错误识别刻律德拉晋阶材料（在易识别错误的地方进行了替换）

日志：
INFO     22:55:14.082 │ [OCR_RESULT 0.298s] ['暮晖煜蕾', '65', '0', '65', '天外乐章', '139', 
         '0', '137', '空际小节', '69', '1', '62', '云际音符', '18', '0', '0', '命运的足迹',  
         '8', '0', '0', '阳雷的遥想', '12', 'o', '0', '哀叹漫无止息', '73', '71', '0',       
         '悲鸣由远及近', '71', '67', '0']   
因OCR识别错误导致无法识别该材料