### PR TITLE
Fix Bug: Incorrectly identifying dungeon name of Cerydra

### DIFF
--- a/tasks/dungeon/ui/llist.py
+++ b/tasks/dungeon/ui/llist.py
@@ -56,6 +56,8 @@ class OcrDungeonName(Ocr):
             result = re.sub('^偶之形', '偃偶之形', result)
             # 嗔怒之形•凝滞虚影
             result = re.sub('^怒之形', '嗔怒之形', result)
+            # 烬日之形•凝滞虚影
+            result = re.sub('^日之形', '烬日之形', result)
             # 蛀星的旧·历战余响
             result = re.sub(r'蛀星的旧.?历战.+$', '蛀星的旧魇•历战的余响', result)
             result = re.sub(r'蛀星的旧.?历战?$', '蛀星的旧魇•历战', result)


### PR DESCRIPTION
修复了任务无法识别刻律德拉的晋阶材料副本

日志：
2025-08-27 00:11:40.683 | INFO | [OcrDungeonList 0.238s] ['震厄之形', '进入', '〇迥星港', '鸣雷之形', '进入',           '●残响回廊', '日之形', '进入', '「穹顶关塞」晨昏之眼', '今宵之形', '进入', '匹诺康尼大剧院']           
仍然是OCR识别错误