### PR TITLE
Fix: MuMuPlayer12 failing to close as expected #934 #921 #880

### DIFF
--- a/module/device/platform/emulator_windows.py
+++ b/module/device/platform/emulator_windows.py
@@ -169,7 +169,7 @@ class Emulator(EmulatorBase):
         if 'MuMuPlayer.exe' in exe:
             return exe.replace('MuMuPlayer.exe', 'MuMuManager.exe')
         # MuMuPlayer12 5.0
-        elif 'MuMuPlayer.exe' in exe:
+        elif 'MuMuNxMain.exe' in exe:
             return exe.replace('MuMuNxMain.exe', 'MuMuManager.exe')
         elif 'LDPlayer.exe' in exe:
             return exe.replace('LDPlayer.exe', 'ldconsole.exe')


### PR DESCRIPTION
https://github.com/LmeSzinc/StarRailCopilot/blob/b6c1f1de97e339cabf15b06913166f026081e99c/module/device/platform/emulator_windows.py#L172

只是改了程序名 现在仍然使用旧版的关闭指令