### PR TITLE
Increase stuck timer duration from 60 to 120 seconds

### DIFF
--- a/module/device/device.py
+++ b/module/device/device.py
@@ -68,7 +68,7 @@ class Device(Screenshot, Control, AppControl):
     _screen_size_checked = False
     detect_record = set()
     click_record = collections.deque(maxlen=30)
-    stuck_timer = Timer(60, count=60).start()
+    stuck_timer = Timer(120, count=120).start()
 
     def __init__(self, *args, **kwargs):
         for trial in range(4):


### PR DESCRIPTION
由于副本连续挑战次数增多，适当增加游戏副本等待时间，修复比如连续挑战三次周本可能会导致的超时
Due to the increase in the number of consecutive challenges of the replica, the waiting time of the game replica should be appropriately increased. For example, the timeout that might be caused by three consecutive challenges for a week should be fixed