### PR TITLE
Fix: MuMuPlayer12 failing to launch when starting multiple instances concurrently

### DIFF
--- a/module/device/platform/platform_windows.py
+++ b/module/device/platform/platform_windows.py
@@ -96,11 +96,14 @@ class PlatformWindows(PlatformBase, EmulatorManager):
             # NemuPlayer.exe -m nemu-12.0-x64-default
             self.execute(f'"{exe}" -m {instance.name}')
         elif instance == Emulator.MuMuPlayer12:
-            # MuMuPlayer.exe -v 0
-            # MuMuNxMain.exe -v 0
+            # MuMuManager.exe api -v 0 launch_player
+            # Launch via MuMuManager instead of MuMuPlayer.exe/MuMuNxMain.exe.
+            # MuMuNxMain.exe is a GUI singleton, if two instances get launched at the same time,
+            # the second launch request is handed over to a MuMuNxMain.exe that is still initializing
+            # and gets silently dropped, while MuMuManager queues requests in backend service.
             if instance.MuMuPlayer12_id is None:
                 logger.warning(f'Cannot get MuMu instance index from name {instance.name}')
-            self.execute(f'"{exe}" -v {instance.MuMuPlayer12_id}')
+            self.execute(f'"{Emulator.single_to_console(exe)}" api -v {instance.MuMuPlayer12_id} launch_player')
         elif instance == Emulator.LDPlayerFamily:
             # ldconsole.exe launch --index 0
             self.execute(f'"{Emulator.single_to_console(exe)}" launch --index {instance.LDPlayer_id}')
@@ -318,9 +321,12 @@ class PlatformWindows(PlatformBase, EmulatorManager):
                 return False
             # Start
             if self._emulator_function_wrapper(self._emulator_start):
-                # Success
-                self.emulator_start_watch()
-                return True
+                if self.emulator_start_watch():
+                    # Success
+                    return True
+                else:
+                    # Start command was sent but emulator didn't come online, stop and start again
+                    continue
             else:
                 # Failed to start, stop and start again
                 if self._emulator_function_wrapper(self._emulator_stop):


### PR DESCRIPTION
## 问题

多个 Alas/SRC 实例同时启动各自的 MuMu12 模拟器实例时（典型场景：两个配置的任务都在凌晨 4 点到期），经常只有一个模拟器能启动，另一个永远起不来，且日志中无任何报错，只有 `Emulator start` 之后长时间的 adb 连接失败。

#904 报告过相同症状（"4点任务开始时模拟器无法正常启动，每日稳定复现"），其根因（device 缓存未清除）已由 #916 修复；本 PR 处理的是同一症状的另一个独立根因，两者互补。

## 根因

1. **并发启动命令被静默丢弃**。当前代码用 `MuMuNxMain.exe -v N` 启动实例，而 MuMuNxMain 是 GUI 单例进程：冷启动状态下两条命令几乎同时到达时，第二条命令会被移交给一个尚在初始化中的主进程并被静默丢弃——没有任何报错，该实例的进程根本不会创建。竞态窗口为亚秒级（空闲机器实测 0.3s 间隔必现、1.5s 间隔不触发），系统负载越高窗口越宽，因此表现为"概率性失败"。
2. **启动超时被误报为成功**。`emulator_start()` 中 `emulator_start_watch()` 的返回值被忽略，等待 180 秒超时后依然 `return True`。上层误以为启动成功，连接失败后再次进入启动流程，而流程第一步的无条件 shutdown 可能把正在缓慢启动的实例打断重来，进一步放大问题。

## 修复

1. MuMu12 改用 `MuMuManager.exe api -v N launch_player` 启动。MuMuManager 将命令交给常驻后台服务（MuMuNxService）排队处理并同步返回结果码，并发命令不会互吞。这与现有的关闭命令 `api -v N shutdown_player` 完全对称（#936 修复了关闭路径的 exe 转换，本 PR 把启动路径补齐到同一架构），也与同函数中雷电模拟器经 `ldconsole.exe launch` 启动的做法一致。
2. `emulator_start()` 尊重 `emulator_start_watch()` 的返回值：超时不再误报成功，而是复用既有的 stop→start 重试循环（上限 3 次，与原逻辑一致，无新增等待语句）。

## 复现与验证

环境：MuMu 12 V5.0（MuMuNxMain），双实例，每次实验前恢复相同冷状态（两实例关机、无 MuMuNxMain 进程，等价于凌晨 4 点）。

| 启动方式 | 命令间隔 | 结果 |
|---|---|---|
| `MuMuNxMain.exe -v 0` / `-v 1`（现状） | 1.5s | 两实例均启动 |
| `MuMuNxMain.exe -v 0` / `-v 1`（现状） | **0.33s** | **实例 0 启动；实例 1 进程 150s+ 从未出现**（`MuMuManager info` 持续显示 `is_process_started=false`，全程无报错） |
| `MuMuManager api launch_player`（本 PR） | **0.30s** | **两实例均启动**，20s 内安卓全部就绪 |

端到端验证：应用本 PR 后，两个 Alas 进程（`Device('a')` / `Device('b')`）从冷状态并发启动各自实例，均在约 11s/16s 完成 `Emulator start completed` 并正常连接（adb + nemu_ipc）。

## 兼容性说明

选用 `api launch_player` 而非新式 `control launch`，是为与现有 `api shutdown_player` 保持同一命令族、同一兼容面：`control` 系命令要求 MuMu ≥ V4.0.0.3179，而 `api` 系新旧版本通吃（官方文档注明旧命令"兼容大部分旧命令参数（后面可能会废弃，谨慎使用）"，无移除时间表，已在 V5.0 实测可用）。
