### PR TITLE
fix(webapp): 修复 Electron 启动与退出流程

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ locales/
 v8_context_snapshot.bin
 snapshot_blob.bin
 vk_swiftshader_icd.json
+config/deploy.test.template.yaml
 
 # Created by .ignore support plugin (hsz.mobi)
 

--- a/webapp/packages/common/utils/getAlasABSPath.ts
+++ b/webapp/packages/common/utils/getAlasABSPath.ts
@@ -14,7 +14,10 @@ const getAlasABSPath = (
   const sep = path.sep;
   const fg = require('fast-glob');
   let appAbsPath = process.cwd();
-  if (isMacintosh && import.meta.env.PROD) {
+  // `app` is unavailable in preload, but production Electron processes share execPath.
+  if (!isMacintosh && import.meta.env.PROD) {
+    appAbsPath = path.dirname(process.execPath);
+  } else if (isMacintosh && import.meta.env.PROD) {
     appAbsPath = app?.getAppPath() || process.execPath;
   }
 

--- a/webapp/packages/main/src/addIpcMainListener.ts
+++ b/webapp/packages/main/src/addIpcMainListener.ts
@@ -1,6 +1,7 @@
 import type {CoreService} from '/@/coreService';
+import type {ShutdownCoordinator} from '/@/appShutdown';
 import type {BrowserWindow} from 'electron';
-import {app, ipcMain, nativeTheme} from 'electron';
+import {ipcMain, nativeTheme} from 'electron';
 import {
   ELECTRON_THEME,
   INSTALLER_READY,
@@ -10,7 +11,11 @@ import {
 import {ThemeObj} from '@common/constant/theme';
 import logger from '/@/logger';
 
-export const addIpcMainListener = async (mainWindow: BrowserWindow, coreService: CoreService) => {
+export const addIpcMainListener = async (
+  mainWindow: BrowserWindow,
+  coreService: CoreService,
+  shutdown: ShutdownCoordinator,
+) => {
   // Minimize, maximize, close window.
   ipcMain.on('window-tray', function () {
     mainWindow?.hide();
@@ -22,9 +27,7 @@ export const addIpcMainListener = async (mainWindow: BrowserWindow, coreService:
     mainWindow?.isMaximized() ? mainWindow?.restore() : mainWindow?.maximize();
   });
   ipcMain.on('window-close', function () {
-    coreService?.kill();
-    mainWindow?.close();
-    app.exit(0);
+    void shutdown.request();
   });
 
   ipcMain.on(WINDOW_READY, async function (_, args) {

--- a/webapp/packages/main/src/appShutdown.ts
+++ b/webapp/packages/main/src/appShutdown.ts
@@ -1,0 +1,35 @@
+type StopBackend = () => Promise<void>;
+type QuitElectron = () => void;
+type ReportError = (error: unknown) => void;
+
+export class ShutdownCoordinator {
+  private shutdownPromise: Promise<void> | null = null;
+  private canQuit = false;
+
+  constructor(
+    private readonly stopBackend: StopBackend,
+    private readonly quitElectron: QuitElectron,
+    private readonly reportError: ReportError = () => undefined,
+  ) {}
+
+  get readyToQuit() {
+    return this.canQuit;
+  }
+
+  request(): Promise<void> {
+    if (this.shutdownPromise) return this.shutdownPromise;
+
+    this.shutdownPromise = (async () => {
+      try {
+        await this.stopBackend();
+      } catch (error) {
+        this.reportError(error);
+      }
+
+      this.canQuit = true;
+      this.quitElectron();
+    })();
+
+    return this.shutdownPromise;
+  }
+}

--- a/webapp/packages/main/src/config.ts
+++ b/webapp/packages/main/src/config.ts
@@ -2,6 +2,7 @@ import {isMacintosh} from '@common/utils/env';
 import getAlasABSPath from '@common/utils/getAlasABSPath';
 import {ALAS_INSTR_FILE} from '@common/constant/config';
 import {validateConfigFile} from '@common/utils/validate';
+import {app} from 'electron';
 import {join} from 'path';
 import logger from '/@/logger';
 
@@ -11,7 +12,9 @@ const path = require('path');
 
 function getAlasPath() {
   let file;
-  const currentFilePath = process.cwd();
+  // A packaged app can be launched from a shortcut or another working directory.
+  // Resolve portable backend resources relative to the executable in production.
+  const currentFilePath = app?.isPackaged ? path.dirname(process.execPath) : process.cwd();
   const pathLookup = [
     // Current
     './',

--- a/webapp/packages/main/src/coreService.ts
+++ b/webapp/packages/main/src/coreService.ts
@@ -79,13 +79,19 @@ export class CoreService {
     this.mainWindow?.webContents.send(ALAS_LOG, message);
   }
 
-  kill(callback?: () => void) {
-    this.curService?.kill(callback || this.cb);
-  }
+  kill(): Promise<void> {
+    const service = this.curService;
+    if (!service) return Promise.resolve();
 
-  cb() {
-    /**
-     *
-     */
+    // tree-kill runs taskkill asynchronously on Windows. Resolve only after it completes.
+    return new Promise((resolve, reject) => {
+      service.kill((error?: Error) => {
+        if (error) {
+          reject(error);
+        } else {
+          resolve();
+        }
+      });
+    });
   }
 }

--- a/webapp/packages/main/src/createApp.ts
+++ b/webapp/packages/main/src/createApp.ts
@@ -1,6 +1,7 @@
 import {createMainWindow} from '/@/createMainWindow';
 import {addIpcMainListener} from '/@/addIpcMainListener';
 import {CoreService} from '/@/coreService';
+import {ShutdownCoordinator} from '/@/appShutdown';
 import logger from '/@/logger';
 import {app, nativeImage, Tray} from 'electron';
 import {join} from 'node:path';
@@ -10,6 +11,17 @@ export const createApp = async () => {
   logger.info('-----createMainWindow-----');
   const mainWindow = await createMainWindow();
   const coreService = new CoreService({mainWindow});
+  const shutdown = new ShutdownCoordinator(
+    () => coreService.kill(),
+    () => app.quit(),
+    error => logger.error(`Failed to stop core service: ${String(error)}`),
+  );
+
+  app.on('before-quit', event => {
+    if (shutdown.readyToQuit) return;
+    event.preventDefault();
+    void shutdown.request();
+  });
 
   // Hide menu
   const {Menu} = require('electron');
@@ -34,11 +46,7 @@ export const createApp = async () => {
     {
       label: 'Exit',
       click: function () {
-        coreService.curService?.kill(() => {
-          logger.info('kill coreService');
-        });
-        app.quit();
-        process.exit(0);
+        void shutdown.request();
       },
     },
   ]);
@@ -59,7 +67,7 @@ export const createApp = async () => {
     tray.popUpContextMenu(contextMenu);
   });
 
-  await addIpcMainListener(mainWindow, coreService);
+  await addIpcMainListener(mainWindow, coreService, shutdown);
   return {
     mainWindow,
     coreService,

--- a/webapp/packages/main/src/pyshell.ts
+++ b/webapp/packages/main/src/pyshell.ts
@@ -22,7 +22,7 @@ export class PyShell extends PythonShell {
     return this;
   }
 
-  kill(callback: (...args: any[]) => void): this {
+  kill(callback: (error?: Error) => void): this {
     treeKill(this.childProcess.pid, 'SIGTERM', callback);
     return this;
   }

--- a/webapp/packages/main/src/serviceLogic/createAlas.ts
+++ b/webapp/packages/main/src/serviceLogic/createAlas.ts
@@ -1,7 +1,13 @@
 import {webuiArgs, webuiPath} from '/@/config';
 import {PyShell} from '/@/pyshell';
-import type {CallbackFun} from '/@/coreService';
+import type {CallbackFun, CoreService} from '/@/coreService';
 import logger from '/@/logger';
+
+export function handleAlasEnd(ctx: Pick<CoreService, 'sendLaunchLog'>, err?: string) {
+  if (!err) return;
+  logger.info('alas.end:' + err);
+  ctx.sendLaunchLog(err);
+}
 
 export const createAlas: CallbackFun = async ctx => {
   let alas: PyShell | null = null;
@@ -17,10 +23,7 @@ export const createAlas: CallbackFun = async ctx => {
     ctx.sendLaunchLog(err);
   });
   alas?.end(function (err: string) {
-    if (!err) return;
-    logger.info('alas.end:' + err);
-    ctx.sendLaunchLog(err);
-    throw err;
+    handleAlasEnd(ctx, err);
   });
   alas?.on('stdout', function (message) {
     ctx.sendLaunchLog(message);

--- a/webapp/packages/main/tests/appShutdown.spec.ts
+++ b/webapp/packages/main/tests/appShutdown.spec.ts
@@ -1,0 +1,55 @@
+import {beforeEach, expect, test, vi} from 'vitest';
+import {ShutdownCoordinator} from '../src/appShutdown';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+test('waits for the Python process tree to stop before quitting Electron', async () => {
+  let finishBackendShutdown: (() => void) | undefined;
+  const stopBackend = vi.fn(
+    () =>
+      new Promise<void>(resolve => {
+        finishBackendShutdown = resolve;
+      }),
+  );
+  const quitElectron = vi.fn();
+  const shutdown = new ShutdownCoordinator(stopBackend, quitElectron);
+
+  const completed = shutdown.request();
+
+  expect(stopBackend).toHaveBeenCalledOnce();
+  expect(quitElectron).not.toHaveBeenCalled();
+  expect(shutdown.readyToQuit).toBe(false);
+
+  finishBackendShutdown?.();
+  await completed;
+
+  expect(quitElectron).toHaveBeenCalledOnce();
+  expect(shutdown.readyToQuit).toBe(true);
+});
+
+test('coalesces concurrent shutdown requests', async () => {
+  const stopBackend = vi.fn(() => Promise.resolve());
+  const quitElectron = vi.fn();
+  const shutdown = new ShutdownCoordinator(stopBackend, quitElectron);
+
+  await Promise.all([shutdown.request(), shutdown.request()]);
+
+  expect(stopBackend).toHaveBeenCalledOnce();
+  expect(quitElectron).toHaveBeenCalledOnce();
+});
+
+test('still quits Electron if the backend process is already gone', async () => {
+  const error = new Error('process not found');
+  const stopBackend = vi.fn(() => Promise.reject(error));
+  const quitElectron = vi.fn();
+  const reportError = vi.fn();
+  const shutdown = new ShutdownCoordinator(stopBackend, quitElectron, reportError);
+
+  await shutdown.request();
+
+  expect(reportError).toHaveBeenCalledWith(error);
+  expect(quitElectron).toHaveBeenCalledOnce();
+  expect(shutdown.readyToQuit).toBe(true);
+});

--- a/webapp/packages/main/tests/createAlas.spec.ts
+++ b/webapp/packages/main/tests/createAlas.spec.ts
@@ -1,0 +1,12 @@
+import {expect, test, vi} from 'vitest';
+import {handleAlasEnd} from '../src/serviceLogic/createAlas';
+
+test('does not throw when the backend process ends with shutdown output', () => {
+  const context = {
+    sendLaunchLog: vi.fn(),
+  };
+  const shutdownOutput = 'INFO: Uvicorn running on http://127.0.0.1:22370';
+
+  expect(() => handleAlasEnd(context, shutdownOutput)).not.toThrow();
+  expect(context.sendLaunchLog).toHaveBeenCalledWith(shutdownOutput);
+});

--- a/webapp/scripts/watch.mjs
+++ b/webapp/scripts/watch.mjs
@@ -17,7 +17,7 @@ const logLevel = 'warn';
  * Needs to set up `VITE_DEV_SERVER_URL` environment variable from {@link import('vite').ViteDevServer.resolvedUrls}
  */
 function setupMainPackageWatcher({resolvedUrls}) {
-  process.env.VITE_DEV_SERVER_URL = resolvedUrls.local[0];
+  process.env.VITE_DEV_SERVER_URL = new URL('index.html', resolvedUrls.local[0]).href;
 
   /** @type {ChildProcess | null} */
   let electronApp = null;


### PR DESCRIPTION
## 修改内容

- 统一 Electron 的所有退出入口，等待 Python 进程树停止后再退出主进程
- 避免将正常关闭时的 `python-shell` 输出再次抛出为主进程未捕获异常
- 在开发模式下显式加载 Vite 的入口页面，并以可执行文件位置解析打包后的项目资源
- 补充并发退出、后端进程已不存在及后端结束输出的回归测试

## 问题原因

Windows 下原有逻辑会在异步 `tree-kill` 回调完成前调用 `app.exit()` 或 `process.exit()`，可能导致 Python WebUI 进程残留。主动结束 Python 后，`python-shell` 还可能把缓存的 Uvicorn stderr 作为错误返回；原代码再次抛出该错误，最终显示为 JavaScript 错误弹窗。

开发启动脚本此前还会把 Vite 根地址传给 Electron，但该地址在当前配置下返回 404。打包版则依赖 `process.cwd()` 查找资源，从快捷方式或其他工作目录启动便携版时，可能无法找到 `deploy.yaml`、Python 或 `gui.py`。

## 影响

- 窗口关闭、托盘退出和 Electron 生命周期退出共用同一个幂等关闭流程
- 等待后端停止，并在关闭失败时记录日志而不阻塞 Electron 退出
- 开发模式可以稳定加载正确的 Vite 页面
- Windows 打包版不再依赖启动时的工作目录查找后端资源

## 验证

- `npx vitest run -r packages/main tests/appShutdown.spec.ts tests/createAlas.spec.ts`
- 对所有修改的 TypeScript 和 JavaScript 文件执行 ESLint
- `npm run build`
- Windows 集成验证：WebUI 返回 HTTP 200；关闭后 Electron、两个 Python 进程、watch 进程以及 5173/9229/22370 端口均无残留
